### PR TITLE
Add the ability to create own PromptProvider. Fixes #68

### DIFF
--- a/samples/complete/src/main/java/com/github/fonimus/ssh/shell/complete/DemoPromptProvider.java
+++ b/samples/complete/src/main/java/com/github/fonimus/ssh/shell/complete/DemoPromptProvider.java
@@ -1,0 +1,17 @@
+package com.github.fonimus.ssh.shell.complete;
+
+import org.jline.utils.AttributedString;
+import org.springframework.shell.jline.PromptProvider;
+import org.springframework.stereotype.Component;
+
+import static org.jline.utils.AttributedStyle.CYAN;
+import static org.jline.utils.AttributedStyle.DEFAULT;
+
+@Component
+public class DemoPromptProvider implements PromptProvider {
+
+  @Override
+  public AttributedString getPrompt() {
+    return new AttributedString("complete::>", DEFAULT.foreground(CYAN));
+  }
+}

--- a/samples/complete/src/main/resources/application.yml
+++ b/samples/complete/src/main/resources/application.yml
@@ -3,9 +3,6 @@ ssh:
     actuator:
       excludes:
       - audit
-    prompt:
-      color: cyan
-      text: 'complete::>'
     authentication: security
     auth-provider-bean-name: customAuthManager
     any-os-file-provider: false

--- a/starter/src/main/java/com/github/fonimus/ssh/shell/SshShellAutoConfiguration.java
+++ b/starter/src/main/java/com/github/fonimus/ssh/shell/SshShellAutoConfiguration.java
@@ -170,7 +170,7 @@ public class SshShellAutoConfiguration {
      * @return prompt provider
      */
     @Bean
-    @Primary
+    @ConditionalOnMissingBean
     public PromptProvider sshPromptProvider(SshShellProperties properties) {
         return () -> new AttributedString(properties.getPrompt().getText(),
                 AttributedStyle.DEFAULT.foreground(properties.getPrompt().getColor().toJlineAttributedStyle()));


### PR DESCRIPTION
Fixes #68
- use users `PromptProvider`
- use default `PromptProvider` if other not defined