### PR TITLE
Fix a warn when application shut down

### DIFF
--- a/starter/src/main/java/com/github/fonimus/ssh/shell/SshShellAutoConfiguration.java
+++ b/starter/src/main/java/com/github/fonimus/ssh/shell/SshShellAutoConfiguration.java
@@ -127,7 +127,7 @@ public class SshShellAutoConfiguration {
     public void init() {
         if (context.getEnvironment().getProperty("spring.main.lazy-initialization", Boolean.class, false)) {
             LOGGER.info("Lazy initialization enabled, calling configuration bean explicitly to start ssh server");
-            context.getBean(SshShellConfiguration.class);
+            context.getBean(SshShellConfiguration.SshServerLifecycle.class);
             // also need to get terminal to initialize thread context of main thread
             context.getBean(Terminal.class);
         }


### PR DESCRIPTION
Hi,

I noticed this log that happens when the Spring context is destroying the beans : 

````
2021-05-01 12:21:49.580  WARN 15516 --- [      Thread-23] .s.c.a.CommonAnnotationBeanPostProcessor : Destroy method on bean with name 'sshShellConfiguration' threw an exception: org.springframework.beans.factory.BeanCreationNotAllowedException: Error creating bean with name 'sshServer': Singleton bean creation not allowed while singletons of this factory are in destruction (Do not request a bean from a BeanFactory in a destroy method implementation!)
````

So this pull request fixes it. If you want to reproduce the "bug" you can add this in your main method : 
````java
public static void main(String[] args) {
    ConfigurableApplicationContext ctx = SpringApplication.run(CompleteApplication.class, args);
    new Thread(() -> {
        try {
            Thread.sleep(5000);
            ctx.stop();
        } catch (InterruptedException e) {
            e.printStackTrace();
        }
    }).start();
}
````

Not related, I created this Markdown extension to generate a documentation from (Ssh)ShellComponent annotated classes : https://github.com/dylan-roger/markdown-spring-shell-documentation/
May be it will interest you if you are still using this library and mkdocs

PS : sorry for the first PR that I closed, I didn't rebase my master