### PR TITLE
Upgrade spring boot 3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 > Spring shell in spring boot application over ssh
 
 For more information please
-visit `spring shell` [website](https://docs.spring.io/spring-shell/docs/3.0.3/docs/index.html).
+visit `spring shell` [website](https://docs.spring.io/spring-shell/reference/3.3/index.html).
 
 * [Getting started](#getting-started)
 * [Commands](#commands)

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.github.fonimus</groupId>
     <artifactId>ssh-shell-spring-boot-parent</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 
@@ -55,9 +55,9 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!--dependencies-->
-        <spring-boot.version>3.2.5</spring-boot.version>
-        <sshd.version>2.12.1</sshd.version>
-        <spring-shell.version>3.2.5</spring-shell.version>
+        <spring-boot.version>3.3.8</spring-boot.version>
+        <sshd.version>2.13.2</sshd.version>
+        <spring-shell.version>3.3.4</spring-shell.version>
         <junit-jupiter.version>5.10.2</junit-jupiter.version>
         <!--sonar-->
         <sonar.projectKey>fonimus_ssh-shell-spring-boot</sonar.projectKey>
@@ -192,7 +192,7 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.2.5</version>
+                    <version>3.5.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.github.fonimus</groupId>
     <artifactId>ssh-shell-spring-boot-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 
@@ -55,9 +55,9 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!--dependencies-->
-        <spring-boot.version>3.3.8</spring-boot.version>
+        <spring-boot.version>3.4.2</spring-boot.version>
         <sshd.version>2.13.2</sshd.version>
-        <spring-shell.version>3.3.4</spring-shell.version>
+        <spring-shell.version>3.4.0</spring-shell.version>
         <junit-jupiter.version>5.10.2</junit-jupiter.version>
         <!--sonar-->
         <sonar.projectKey>fonimus_ssh-shell-spring-boot</sonar.projectKey>

--- a/samples/basic/pom.xml
+++ b/samples/basic/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>ssh-shell-spring-boot-parent</artifactId>
         <groupId>com.github.fonimus</groupId>
-        <version>3.2.0-SNAPSHOT</version>
+        <version>3.3.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/basic/pom.xml
+++ b/samples/basic/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>ssh-shell-spring-boot-parent</artifactId>
         <groupId>com.github.fonimus</groupId>
-        <version>3.1.1-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/complete/pom.xml
+++ b/samples/complete/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>ssh-shell-spring-boot-parent</artifactId>
         <groupId>com.github.fonimus</groupId>
-        <version>3.2.0-SNAPSHOT</version>
+        <version>3.3.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/complete/pom.xml
+++ b/samples/complete/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>ssh-shell-spring-boot-parent</artifactId>
         <groupId>com.github.fonimus</groupId>
-        <version>3.1.1-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/starter/pom.xml
+++ b/starter/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>ssh-shell-spring-boot-parent</artifactId>
         <groupId>com.github.fonimus</groupId>
-        <version>3.2.0-SNAPSHOT</version>
+        <version>3.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/starter/pom.xml
+++ b/starter/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>ssh-shell-spring-boot-parent</artifactId>
         <groupId>com.github.fonimus</groupId>
-        <version>3.1.1-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/starter/src/main/java/com/github/fonimus/ssh/shell/ExtendedInteractiveShellRunner.java
+++ b/starter/src/main/java/com/github/fonimus/ssh/shell/ExtendedInteractiveShellRunner.java
@@ -36,15 +36,14 @@ public class ExtendedInteractiveShellRunner extends InteractiveShellRunner {
     }
 
     @Override
-    public void run(ApplicationArguments args) throws Exception {
+    public boolean run(String[] args) throws Exception {
+        if (args == null || args.length == 0) {
+            return false;
+        }
         shellContext.setInteractionMode(InteractionMode.INTERACTIVE);
         InputProvider inputProvider = new SshShellInputProvider(lineReader, promptProvider);
         shell.run(inputProvider);
-    }
-
-    @Override
-    public boolean canRun(ApplicationArguments args) {
-        return false;
+        return true;
     }
 
     public static class SshShellInputProvider

--- a/starter/src/main/java/com/github/fonimus/ssh/shell/SshShellRunnable.java
+++ b/starter/src/main/java/com/github/fonimus/ssh/shell/SshShellRunnable.java
@@ -157,7 +157,7 @@ public class SshShellRunnable
 
                 SSH_THREAD_CONTEXT.set(new SshContext(this, terminal, reader, authentication));
                 shellListenerService.onSessionStarted(session);
-                new InteractiveShellRunner(reader, promptProvider, shell, new DefaultShellContext()).run(null);
+                new InteractiveShellRunner(reader, promptProvider, shell, new DefaultShellContext()).run((String[]) null);
                 shellListenerService.onSessionStopped(session);
                 LOGGER.debug("{}: closing", session);
                 quit(0);

--- a/starter/src/main/java/com/github/fonimus/ssh/shell/commands/TasksCommand.java
+++ b/starter/src/main/java/com/github/fonimus/ssh/shell/commands/TasksCommand.java
@@ -28,6 +28,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.task.TaskRejectedException;
+import org.springframework.scheduling.SchedulingAwareRunnable;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
 import org.springframework.scheduling.config.*;
@@ -354,7 +355,9 @@ public class TasksCommand extends AbstractCommand implements DisposableBean {
     }
 
     private static String getTaskName(Runnable runnable) {
-        if (runnable instanceof ScheduledMethodRunnable) {
+        if (runnable instanceof SchedulingAwareRunnable sar) {
+            return sar.toString();
+        } else if (runnable instanceof ScheduledMethodRunnable) {
             Method method = ((ScheduledMethodRunnable) runnable).getMethod();
             return method.getDeclaringClass().getName() + "." + method.getName();
         } else {

--- a/starter/src/main/java/com/github/fonimus/ssh/shell/commands/actuator/ActuatorCommand.java
+++ b/starter/src/main/java/com/github/fonimus/ssh/shell/commands/actuator/ActuatorCommand.java
@@ -36,6 +36,7 @@ import org.springframework.boot.actuate.logging.LoggersEndpoint;
 import org.springframework.boot.actuate.management.ThreadDumpEndpoint;
 import org.springframework.boot.actuate.metrics.MetricsEndpoint;
 import org.springframework.boot.actuate.scheduling.ScheduledTasksEndpoint;
+import org.springframework.boot.actuate.session.SessionsDescriptor;
 import org.springframework.boot.actuate.session.SessionsEndpoint;
 import org.springframework.boot.actuate.web.exchanges.HttpExchangesEndpoint;
 import org.springframework.boot.actuate.web.mappings.MappingsEndpoint;
@@ -407,7 +408,7 @@ public class ActuatorCommand extends AbstractCommand {
      */
     @ShellMethod(key = "sessions", value = "Display sessions endpoint.")
     @ShellMethodAvailability("sessionsAvailability")
-    public SessionsEndpoint.SessionsDescriptor sessions() {
+    public SessionsDescriptor sessions() {
         return applicationContext.getBean(SessionsEndpoint.class).sessionsForUsername(null);
     }
 

--- a/starter/src/test/java/com/github/fonimus/ssh/shell/SshShellApplicationCustomAuthenticatorTest.java
+++ b/starter/src/test/java/com/github/fonimus/ssh/shell/SshShellApplicationCustomAuthenticatorTest.java
@@ -17,6 +17,7 @@
 package com.github.fonimus.ssh.shell;
 
 import com.github.fonimus.ssh.shell.conf.SshShellPasswordConfigurationTest;
+import com.github.fonimus.ssh.shell.conf.SshShellSessionConfigurationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -27,7 +28,7 @@ import java.util.Map;
 import static com.github.fonimus.ssh.shell.SshHelperTest.*;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
-        classes = {SshShellApplicationCustomAuthenticatorTest.class, SshShellPasswordConfigurationTest.class},
+        classes = {SshShellApplicationCustomAuthenticatorTest.class, SshShellPasswordConfigurationTest.class, SshShellSessionConfigurationTest.class},
         properties = {
                 "ssh.shell.port=2349",
                 "management.endpoints.web.exposure.include=*",

--- a/starter/src/test/java/com/github/fonimus/ssh/shell/SshShellApplicationExclusionsTest.java
+++ b/starter/src/test/java/com/github/fonimus/ssh/shell/SshShellApplicationExclusionsTest.java
@@ -16,6 +16,8 @@
 
 package com.github.fonimus.ssh.shell;
 
+import com.github.fonimus.ssh.shell.conf.SshShellPasswordConfigurationTest;
+import com.github.fonimus.ssh.shell.conf.SshShellSessionConfigurationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -24,8 +26,9 @@ import org.springframework.test.annotation.DirtiesContext;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes =
-        SshShellApplicationExclusionsTest.class, properties = {
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+        classes = {SshShellApplicationExclusionsTest.class, SshShellSessionConfigurationTest.class},
+        properties = {
         "ssh.shell.port=2344",
         "ssh.shell.commands.actuator.excludes[0]=info",
         "ssh.shell.commands.actuator.excludes[1]=beans",

--- a/starter/src/test/java/com/github/fonimus/ssh/shell/commands/ScriptCommandTest.java
+++ b/starter/src/test/java/com/github/fonimus/ssh/shell/commands/ScriptCommandTest.java
@@ -49,7 +49,7 @@ public class ScriptCommandTest {
 
     @BeforeEach
     @SneakyThrows
-    void setUp() {
+    void setUp() throws Exception {
         shell = mock(ExtendedShell.class);
         Parser parser = mock(Parser.class);
         sshHelper = mock(SshShellHelper.class);

--- a/starter/src/test/java/com/github/fonimus/ssh/shell/commands/system/SystemCommandTest.java
+++ b/starter/src/test/java/com/github/fonimus/ssh/shell/commands/system/SystemCommandTest.java
@@ -22,6 +22,8 @@ import org.jline.terminal.Size;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.PrintWriter;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
@@ -51,6 +53,10 @@ class SystemCommandTest extends AbstractShellHelperTest {
         for (SystemCommand.ThreadColumn tc : SystemCommand.ThreadColumn.values()) {
             assertNotNull(command.threads(SystemCommand.ThreadAction.list, tc, true, true, null));
         }
+        // Hint: We have to override the PrintWriterAccess otherwise Thread.printStackTrace() will fail with:
+        // java.lang.NullPointerException: Cannot enter synchronized block because "lock" is null
+        writer = new PrintWriter(PrintWriter.nullWriter()); //Hint: mock(PrintWriter.class); fails in Throwable.printStackTrace()
+        when(ter.writer()).thenReturn(writer);
         assertNotNull(command.threads(SystemCommand.ThreadAction.dump, SystemCommand.ThreadColumn.name, true, true,
                 Thread.currentThread().getId()));
         assertThrows(IllegalArgumentException.class,

--- a/starter/src/test/java/com/github/fonimus/ssh/shell/conf/SshShellSecurityConfigurationTest.java
+++ b/starter/src/test/java/com/github/fonimus/ssh/shell/conf/SshShellSecurityConfigurationTest.java
@@ -37,10 +37,10 @@ public class SshShellSecurityConfigurationTest {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http, AuthenticationManager authManager) throws Exception {
-        http.authorizeHttpRequests()
-                .requestMatchers(EndpointRequest.to("info")).permitAll()
-                .requestMatchers(EndpointRequest.toAnyEndpoint()).hasRole("ACTUATOR")
-                .and().authenticationManager(authManager);
+        http.authorizeHttpRequests((authorizeHttpRequests) -> {
+            authorizeHttpRequests.requestMatchers(EndpointRequest.to("info")).permitAll();
+            authorizeHttpRequests.requestMatchers(EndpointRequest.toAnyEndpoint()).hasRole("ACTUATOR");
+        }).authenticationManager(authManager);
         return http.build();
     }
 

--- a/starter/src/test/java/com/github/fonimus/ssh/shell/conf/SshShellSessionConfigurationTest.java
+++ b/starter/src/test/java/com/github/fonimus/ssh/shell/conf/SshShellSessionConfigurationTest.java
@@ -16,11 +16,16 @@
 
 package com.github.fonimus.ssh.shell.conf;
 
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.actuate.session.SessionsEndpoint;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.session.FindByIndexNameSessionRepository;
+import org.springframework.session.SessionRepository;
 import org.springframework.session.jdbc.config.annotation.web.http.EnableJdbcHttpSession;
 import org.springframework.transaction.PlatformTransactionManager;
 
@@ -39,5 +44,11 @@ public class SshShellSessionConfigurationTest {
     @Bean
     public PlatformTransactionManager transactionManager(DataSource dataSource) {
         return new DataSourceTransactionManager(dataSource);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    SessionsEndpoint sessionEndpoint(SessionRepository<?> sessionRepository, ObjectProvider<FindByIndexNameSessionRepository<?>> indexedSessionRepository) {
+        return new SessionsEndpoint(sessionRepository, (FindByIndexNameSessionRepository) indexedSessionRepository.getIfAvailable());
     }
 }


### PR DESCRIPTION
Hi,

we had to upgrade our project to a supported spring boot release, so we had to get ssh-shell-spring-boot working with it.

This is the second PR (based on the #403 ) where we made the step between spring-boot 3.3.8 -> 3.4.2. It also updates spring-shell 3.3.4 -> 3.4.0.

All junit tests succeed and also some basic interactive tests are working.

Bye,
   Chris